### PR TITLE
🐛 코드 생성 과정에서 누락된 부분을 해결한다

### DIFF
--- a/src/config-builders/route-config.ts
+++ b/src/config-builders/route-config.ts
@@ -16,9 +16,15 @@ export function generateConfig(route: ParsedRoute) {
       },
       query: {
         dtoName: '',
+        schema: {
+          name: '',
+        },
       },
       headers: {
         dtoName: '',
+        schema: {
+          name: '',
+        },
       },
       payload: {
         dtoName: '',
@@ -54,8 +60,8 @@ export function generateConfig(route: ParsedRoute) {
     configMutators.setRequestFunctionName,
     configMutators.setPathParamsSignatures,
     configMutators.setPathParamsArguments,
-    configMutators.setQueryParamsDtoName,
-    configMutators.setHeaderDtoName,
+    configMutators.setQueryInfo,
+    configMutators.setHeaderInfo,
     configMutators.setPayloadDtoName,
     configMutators.setRequestFunctionOptionsTypeExpression,
     configMutators.setRequestRequiredSignatures,
@@ -95,18 +101,20 @@ function withRoute(route: ParsedRoute) {
           }) ?? [];
       });
     },
-    setQueryParamsDtoName: (config: RouteConfig): RouteConfig => {
+    setQueryInfo: (config: RouteConfig): RouteConfig => {
       const { request, routeName } = route;
 
       return produce(config, draft => {
         draft.request.query.dtoName = request.query ? pascalCase(`${routeName.original}QueryParams`) : null;
+        draft.request.query.schema.name = request.query ? `${routeName.original}QueryParamsSchema` : '';
       });
     },
-    setHeaderDtoName: (config: RouteConfig): RouteConfig => {
+    setHeaderInfo: (config: RouteConfig): RouteConfig => {
       const { request, routeName } = route;
 
       return produce(config, draft => {
         draft.request.headers.dtoName = request.headers ? pascalCase(`${routeName.original}Headers`) : null;
+        draft.request.headers.schema.name = request.headers ? `${routeName.original}HeadersSchema` : '';
       });
     },
     setPayloadDtoName: (config: RouteConfig): RouteConfig => {

--- a/src/templates/imports/schema-import.ejs
+++ b/src/templates/imports/schema-import.ejs
@@ -3,12 +3,15 @@
 * @description Schema import 구문 생성 템플릿 입니다. api.ejs에서 호출합니다.
 */
 
-const { route, codegenConfig, resolveRelativeImportPath } = it;
+const { route, contractList, codegenConfig, resolveRelativeImportPath } = it;
 const routes = route.routes;
 const { pathInfo } = codegenConfig.customOutput
 
 const schemaAlias = resolveRelativeImportPath(pathInfo.schema.output.relative)
-const allSchemaList = [...routes.map(({routeConfig}) => [...routeConfig.request.schema.list, ...routeConfig.response.schema.list]).flat()].join(",");
+const allSchemaList = [...routes.map(({routeConfig}) => [
+  ...routeConfig.request.schema.list, ...routeConfig.response.schema.list, routeConfig.request.query.schema.name, routeConfig.request.headers.schema.name].filter(Boolean)).flat(),
+  ...(contractList ?? []).map(contract=>contract.schemaName)
+].join(",");
 %>
 
 <%~ allSchemaList.length > 0 ? `import { ${allSchemaList} } from '${schemaAlias}';` : "" %>

--- a/src/templates/tanstack-query/mutations.ejs
+++ b/src/templates/tanstack-query/mutations.ejs
@@ -7,9 +7,10 @@ const { utils, route, modelTypes, config } = it;
 const { pascalCase } = utils;
 const { moduleName, routes } = route;
 
-const mutationRoutes = routes
-    .filter(({ request: { method } }) => ['post','patch','put','delete'].includes(method))
-    .filter(({ response }) => !response.contentTypes?.includes('text/event-stream'));
+const mutationKeyRoutes = routes
+    .filter(({ request: { method } }) => ['post','patch','put','delete'].includes(method));
+const mutationRoutes = mutationKeyRoutes.filter(({ response }) => !response.contentTypes?.includes('text/event-stream'));
+
 const commonMeta = mutationRoutes.at(0)?.customeMeta;
 const moduleConfig = routes.at(0)?.moduleConfig;
 const codegenConfig = routes.at(0)?.codegenConfig;
@@ -33,7 +34,7 @@ import type { KyInstance, Options } from 'ky';
 
 
 export const <% ~moduleConfig.mutation.mutationKeyObjectName %> = {
-<% for (const {hookConfig: {mutation}} of mutationRoutes) { %>
+<% for (const {hookConfig: {mutation}} of mutationKeyRoutes) { %>
     <% ~mutation.mutationKeyConstanstName %>: <% ~mutation.mutationKeyConstanstContent %>,
 <% } %>
 };

--- a/src/templates/type-guards.ejs
+++ b/src/templates/type-guards.ejs
@@ -41,10 +41,15 @@ const parameterDtoList = routes.combined.map((route) => {
 
 const allDtoList = [...contractList, ...parameterDtoList];
 
-const routeDependency = routes.combined.at(0)
+const allRouteDependencies = routes.combined;
+const flatRoute = allRouteDependencies.reduce((acc, v) => {
+  acc.routes.push(...v.routes);
+  return acc;
+}, {routes: []});
 
-const moduleConfig = routeDependency.routes.at(0)?.moduleConfig;
-const codegenConfig = routeDependency.routes.at(0)?.codegenConfig;
+const firstRoute = allRouteDependencies.at(0)
+const moduleConfig = firstRoute.routes.at(0)?.moduleConfig;
+const codegenConfig = firstRoute.routes.at(0)?.codegenConfig;
 
 const resolveRelativeImportPath = moduleConfig.utils.resolveRelativeImportPath({
   fromPath: codegenConfig.customOutput.pathInfo.typeGuards.output.relative
@@ -55,8 +60,8 @@ const { pathInfo } = codegenConfig.customOutput;
 //TODO: 모든 라우트에 대해 생성되도록 해야함
 %>
 
-<%~ includeFile('./imports/dto-import.ejs', { route: routeDependency, utils, modelTypes, codegenConfig, resolveRelativeImportPath }) %>
-<%~ includeFile('./imports/schema-import.ejs', { route: routeDependency, utils, modelTypes, codegenConfig, resolveRelativeImportPath }) %>
+<%~ includeFile('./imports/dto-import.ejs', { route: flatRoute, utils, modelTypes, codegenConfig, resolveRelativeImportPath }) %>
+<%~ includeFile('./imports/schema-import.ejs', { route: flatRoute, contractList, utils, modelTypes, codegenConfig, resolveRelativeImportPath }) %>
 
 
 <% for (const parameterDto of allDtoList) { %>

--- a/src/types/route-config.ts
+++ b/src/types/route-config.ts
@@ -1,42 +1,48 @@
 export type RouteConfig = {
-	request: {
-		functionName: string;
-		pathParams: {
-			signatures: string[];
-			arguments: string[];
-		};
-		query: {
-			dtoName: string | null;
-		};
-		headers: {
-			dtoName: string | null;
-		};
-		payload: {
-			dtoName: string | null;
-		};
-		options: {
-			typeExpr: string | null;
-		};
-		parameters: {
-			signatures: {
-				required: string[];
-				all: string[];
-			};
-			arguments: {
-				required: string[];
-				all: string[];
-			};
-		};
-		schema: {
-			list: string[];
-			expression: string | null;
-		};
-	};
-	response: {
-		dtoName: string | null;
-		schema: {
-			list: string[];
-			expression: string | null;
-		};
-	};
+  request: {
+    functionName: string;
+    pathParams: {
+      signatures: string[];
+      arguments: string[];
+    };
+    query: {
+      dtoName: string | null;
+      schema: {
+        name: string;
+      };
+    };
+    headers: {
+      dtoName: string | null;
+      schema: {
+        name: string;
+      };
+    };
+    payload: {
+      dtoName: string | null;
+    };
+    options: {
+      typeExpr: string | null;
+    };
+    parameters: {
+      signatures: {
+        required: string[];
+        all: string[];
+      };
+      arguments: {
+        required: string[];
+        all: string[];
+      };
+    };
+    schema: {
+      list: string[];
+      expression: string | null;
+    };
+  };
+  response: {
+    dtoName: string | null;
+    schema: {
+      list: string[];
+      expression: string | null;
+    };
+  };
 };


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

### 🐛 문제 정의
Type Guards 템플릿에서 `routeDependency`가 첫 번째 라우터만 참조하여 모든 라우터의 import 구문이 제대로 생성되지 않는 문제가 있었습니다. 이로 인해 일부 DTO와 스키마에 대한 type guard 함수가 누락되거나 import 오류가 발생했습니다.

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

### 🔑 Key changes - 주요 변화

1. **Type Guards 템플릿 개선**
   - `routeDependency`를 모든 라우터를 포함하는 `flatRoute`로 변경
   - 모든 라우터의 routes를 하나로 병합하여 완전한 import 구문 생성

2. **Route Config 타입 확장**
   - `query`와 `headers`에 스키마 정보 추가
   - 스키마 이름 생성 로직 추가 (`setQueryInfo`, `setHeaderInfo`)

3. **Schema Import 템플릿 개선**
   - Query/Headers 스키마 포함하도록 확장
   - `contractList` 매개변수 추가로 모든 스키마 import 지원

4. **Mutation 템플릿 개선**
   - Mutation key 생성 로직과 실제 mutation 로직 분리
   - Stream 응답 제외 로직 개선

### 상세 변경사항

- **`src/templates/type-guards.ejs`**: 모든 라우터의 정보를 포함하도록 flatRoute 생성
- **`src/config-builders/route-config.ts`**: Query/Headers 스키마 정보 추가
- **`src/templates/imports/schema-import.ejs`**: 모든 스키마 타입 import 지원
- **`src/templates/tanstack-query/mutations.ejs`**: Mutation key와 실제 mutation 분리
- **`src/types/route-config.ts`**: 스키마 타입 정의 추가